### PR TITLE
Configure mkdocs.yml to build API docs correctly

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,10 +31,8 @@ plugins:
             heading_level: 1
       watch:
         - prefect_ray/
-        - README.md
 
 nav:
     - Home: index.md
-    - Tasks: tasks.md
-    - Flows: flows.md
+    - Task Runners: task_runners.md
 


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-ray! 🎉-->

## Summary
Fixes mkdocs.yml configuration to build API pages correctly.

```
nav:
    - Home: index.md
    - Task Runners: task_runners.md
```

Note here that Home is [built from README.md if a separate index.md does not exist](https://www.mkdocs.org/user-guide/writing-your-docs/#index-pages).

Each subpage referenced here must refer to an .md file under /docs, which in turn references a source file containing the docstrings to be rendered:

`::: prefect_ray.task_runners`

## Relevant Issue(s)

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-ray/blob/main/CHANGELOG.md)
