### PR TITLE
Add resources context manager to set CPUs/GPUs for task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `resources` context manager for managing Ray remote resources for a task - [#54](https://github.com/PrefectHQ/prefect-ray/pull/54)
+- `remote_options` context manager for managing Ray remote options for a task - [#54](https://github.com/PrefectHQ/prefect-ray/pull/54)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `resources` context manager for managing Ray remote resources for a task - [#54](https://github.com/PrefectHQ/prefect-ray/pull/54)
+
 ### Changed
 
 ### Deprecated
@@ -24,17 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Released September 8th, 2022
 
 ### Added
-- `pickle5` requirement for Python < 3.8 users [#30](https://github.com/PrefectHQ/prefect-ray/pull/30).
+- `pickle5` requirement for Python < 3.8 users - [#30](https://github.com/PrefectHQ/prefect-ray/pull/30).
 
 ### Fixed
-- Updated `RayTaskRunner` to be compatible with the updated `TaskRunner` interface in the Prefect Core library (v2.3.0) [#35](https://github.com/PrefectHQ/prefect-ray/pull/35)
+- Updated `RayTaskRunner` to be compatible with the updated `TaskRunner` interface in the Prefect Core library (v2.3.0) - [#35](https://github.com/PrefectHQ/prefect-ray/pull/35)
 
 ## 0.1.4
 
 Released on August 2nd, 2022.
 
 ### Added
-- `pickle5` requirement for Python < 3.8 users [#30](https://github.com/PrefectHQ/prefect-ray/pull/30).
+- `pickle5` requirement for Python < 3.8 users - [#30](https://github.com/PrefectHQ/prefect-ray/pull/30).
 
 ## 0.1.3
 
@@ -42,8 +44,8 @@ Released on July 26th, 2022.
 
 ### Changed
 
-- Dropping x86_64 requirement so ray can be automatically installed [#29](https://github.com/PrefectHQ/prefect-ray/pull/29).
-- Examples to better exemplify parallelism [#29](https://github.com/PrefectHQ/prefect-ray/pull/29).
+- Dropping x86_64 requirement so ray can be automatically installed - [#29](https://github.com/PrefectHQ/prefect-ray/pull/29).
+- Examples to better exemplify parallelism - [#29](https://github.com/PrefectHQ/prefect-ray/pull/29).
 
 ## 0.1.2
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,29 @@ pip install s3fs
 RayTaskRunner(address="ray://1.23.199.255:10001")
 ```
 
+## Specifying resources requirements
+
+The `resources` context can be used to control the task’s resource requirements.
+
+For example, we can set the number of CPUs and GPUs to use in a flow:
+
+```python
+from prefect import flow, task
+from prefect_ray.task_runners import RayTaskRunner
+from prefect_ray.context import resources
+
+@task
+def process(x):
+    return x + 1
+
+
+@flow(task_runner=RayTaskRunner())
+def my_flow():
+    # equivalent to setting @ray.remote(num_cpus=4, num_gpus=2)
+    with resources(num_cpus=4, num_gpus=2):
+        process.submit(42)
+```
+
 ## Resources
 
 If you encounter and bugs while using `prefect-ray`, feel free to open an issue in the [prefect-ray](https://github.com/PrefectHQ/prefect-ray) repository.

--- a/README.md
+++ b/README.md
@@ -193,16 +193,16 @@ pip install s3fs
 RayTaskRunner(address="ray://1.23.199.255:10001")
 ```
 
-## Specifying resources requirements
+## Specifying remote options
 
-The `resources` context can be used to control the task’s resource requirements.
+The `remote_options` context can be used to control the task’s remote options.
 
 For example, we can set the number of CPUs and GPUs to use for the `process` task:
 
 ```python
 from prefect import flow, task
 from prefect_ray.task_runners import RayTaskRunner
-from prefect_ray.context import resources
+from prefect_ray.context import remote_options
 
 @task
 def process(x):
@@ -212,7 +212,7 @@ def process(x):
 @flow(task_runner=RayTaskRunner())
 def my_flow():
     # equivalent to setting @ray.remote(num_cpus=4, num_gpus=2)
-    with resources(num_cpus=4, num_gpus=2):
+    with remote_options(num_cpus=4, num_gpus=2):
         process.submit(42)
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ RayTaskRunner(address="ray://1.23.199.255:10001")
 
 The `resources` context can be used to control the task’s resource requirements.
 
-For example, we can set the number of CPUs and GPUs to use in a flow:
+For example, we can set the number of CPUs and GPUs to use for the `process` task:
 
 ```python
 from prefect import flow, task

--- a/prefect_ray/context.py
+++ b/prefect_ray/context.py
@@ -33,11 +33,12 @@ class RemoteOptionsContext(ContextModel):
 @contextmanager
 def remote_options(**new_remote_options: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Context manager to add remote_options to flow and task run calls.
-    RemoteOptions are always combined with any existing remote_options.
+    Context manager to add keyword arguments to Ray `@remote` calls
+    for task runs. If contexts are nested, new options are merged with options
+    in the outer context. If a key is present in both, the new option will be used.
 
     Yields:
-        The current set of remote_options.
+        The current set of remote options.
 
     Examples:
         Use 4 CPUs and 2 GPUs for the `process` task:

--- a/prefect_ray/context.py
+++ b/prefect_ray/context.py
@@ -1,0 +1,60 @@
+"""
+Contexts to manage Ray clusters and tasks.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Dict
+
+from prefect.context import ContextModel, ContextVar
+from pydantic import Field
+
+
+class ResourcesContext(ContextModel):
+    """
+    The context for Ray resources management.
+
+    Attributes:
+        current_resources: A set of current resources in the context.
+    """
+
+    current_resources: Dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def get(cls) -> "ResourcesContext":
+        """Return an empty `ResourcesContext` instead of `None` if no context exists."""
+        return cls.__var__.get(ResourcesContext())
+
+    __var__ = ContextVar("resources")
+
+
+@contextmanager
+def resources(**new_resources: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Context manager to add resources to flow and task run calls.
+    Resources are always combined with any existing resources.
+
+    Yields:
+        The current set of resources.
+
+    Examples:
+        Use 4 CPUs and 2 GPUs for the `process` task:
+        ```python
+        from prefect import flow, task
+        from prefect_ray.task_runners import RayTaskRunner
+        from prefect_ray.context import resources
+
+        @task
+        def process(x):
+            return x + 1
+
+        @flow(task_runner=RayTaskRunner())
+        def my_flow():
+            # equivalent to setting @ray.remote(num_cpus=4, num_gpus=2)
+            with resources(num_cpus=4, num_gpus=2):
+                process.submit(42)
+        ```
+    """
+    current_resources = ResourcesContext.get().current_resources
+    new_resources.update(**current_resources)
+    with ResourcesContext(current_resources=new_resources):
+        yield

--- a/prefect_ray/task_runners.py
+++ b/prefect_ray/task_runners.py
@@ -84,7 +84,7 @@ from prefect.task_runners import BaseTaskRunner, R, TaskConcurrencyType
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.collections import visit_collection
 
-from prefect_ray.context import ResourcesContext
+from prefect_ray.context import RemoteOptionsContext
 
 
 class RayTaskRunner(BaseTaskRunner):
@@ -146,11 +146,11 @@ class RayTaskRunner(BaseTaskRunner):
 
         call_kwargs = self._optimize_futures(call.keywords)
 
-        remote_resources = ResourcesContext.get().current_resources
+        remote_options = RemoteOptionsContext.get().current_remote_options
         # Ray does not support the submission of async functions and we must create a
         # sync entrypoint
         self._ray_refs[key] = ray.remote(
-            sync_compatible(call.func), **remote_resources
+            sync_compatible(call.func), **remote_options
         ).remote(**call_kwargs)
 
     def _optimize_futures(self, expr):

--- a/prefect_ray/task_runners.py
+++ b/prefect_ray/task_runners.py
@@ -84,6 +84,8 @@ from prefect.task_runners import BaseTaskRunner, R, TaskConcurrencyType
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.collections import visit_collection
 
+from prefect_ray.context import ResourcesContext
+
 
 class RayTaskRunner(BaseTaskRunner):
     """
@@ -144,11 +146,12 @@ class RayTaskRunner(BaseTaskRunner):
 
         call_kwargs = self._optimize_futures(call.keywords)
 
+        remote_resources = ResourcesContext.get().current_resources
         # Ray does not support the submission of async functions and we must create a
         # sync entrypoint
-        self._ray_refs[key] = ray.remote(sync_compatible(call.func)).remote(
-            **call_kwargs
-        )
+        self._ray_refs[key] = ray.remote(
+            sync_compatible(call.func), **remote_resources
+        ).remote(**call_kwargs)
 
     def _optimize_futures(self, expr):
         """

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,26 +1,33 @@
-from prefect_ray.context import ResourcesContext, resources
+from prefect_ray.context import RemoteOptionsContext, remote_options
 
 
-def test_resources_context():
-    input_resources = {"num_cpus": 4}
-    current_resources = ResourcesContext(
-        current_resources=input_resources
-    ).current_resources
-    assert current_resources == input_resources
+def test_remote_options_context():
+    input_remote_options = {"num_cpus": 4}
+    current_remote_options = RemoteOptionsContext(
+        current_remote_options=input_remote_options
+    ).current_remote_options
+    assert current_remote_options == input_remote_options
 
 
-def test_resources_context_get():
-    current_resources = ResourcesContext.get().current_resources
-    assert current_resources == {}
+def test_remote_options_context_get():
+    current_remote_options = RemoteOptionsContext.get().current_remote_options
+    assert current_remote_options == {}
 
 
-def test_resources():
-    with resources(num_cpus=4, num_gpus=None):
-        current_resources = ResourcesContext.get().current_resources
-        assert current_resources == {"num_cpus": 4, "num_gpus": None}
+def test_remote_options():
+    with remote_options(num_cpus=4, num_gpus=None):
+        current_remote_options = RemoteOptionsContext.get().current_remote_options
+        assert current_remote_options == {"num_cpus": 4, "num_gpus": None}
 
 
-def test_resources_empty():
-    with resources():
-        current_resources = ResourcesContext.get().current_resources
-        assert current_resources == {}
+def test_remote_options_empty():
+    with remote_options():
+        current_remote_options = RemoteOptionsContext.get().current_remote_options
+        assert current_remote_options == {}
+
+
+def test_remote_options_override():
+    with remote_options(num_cpus=2, num_gpus=1):
+        with remote_options(num_cpus=4, num_gpus=2):
+            current_remote_options = RemoteOptionsContext.get().current_remote_options
+            assert current_remote_options == {"num_cpus": 4, "num_gpus": 2}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,26 @@
+from prefect_ray.context import ResourcesContext, resources
+
+
+def test_resources_context():
+    input_resources = {"num_cpus": 4}
+    current_resources = ResourcesContext(
+        current_resources=input_resources
+    ).current_resources
+    assert current_resources == input_resources
+
+
+def test_resources_context_get():
+    current_resources = ResourcesContext.get().current_resources
+    assert current_resources == {}
+
+
+def test_resources():
+    with resources(num_cpus=4, num_gpus=None):
+        current_resources = ResourcesContext.get().current_resources
+        assert current_resources == {"num_cpus": 4, "num_gpus": None}
+
+
+def test_resources_empty():
+    with resources():
+        current_resources = ResourcesContext.get().current_resources
+        assert current_resources == {}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to {{ cookiecutter.collection_name }} 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

This PR allows users to [specify required resources](https://docs.ray.io/en/latest/ray-core/tasks/resources.html#), like CPUs and GPUs, for a task.

To accomplish this, we collect resources kwargs from a user through a context manager (see example below), and then pass this to `ray.remote` internally in `submit` [as suggested by Michael.](https://github.com/PrefectHQ/prefect-ray/issues/44#issuecomment-1266254662).

<!-- Link to issue -->
Closes https://github.com/PrefectHQ/prefect-ray/issues/44

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

Use 4 CPUs and 2 GPUs for the `process` task:
```python
from prefect import flow, task
from prefect_ray.task_runners import RayTaskRunner
from prefect_ray.context import resources
@task
def process(x):
    return x + 1
@flow(task_runner=RayTaskRunner())
def my_flow():
    # equivalent to setting @ray.remote(num_cpus=4, num_gpus=2)
    with resources(num_cpus=4, num_gpus=2):
        process.submit(42)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.collection_name }}/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.collection_name }}/blob/main/CHANGELOG.md)
