### PR TITLE
Fix ray remote options

### DIFF
--- a/prefect_ray/task_runners.py
+++ b/prefect_ray/task_runners.py
@@ -150,8 +150,8 @@ class RayTaskRunner(BaseTaskRunner):
         # Ray does not support the submission of async functions and we must create a
         # sync entrypoint
         self._ray_refs[key] = ray.remote(
-            sync_compatible(call.func), **remote_options
-        ).remote(**call_kwargs)
+            sync_compatible(call.func)
+        ).options(**remote_options).remote(**call_kwargs)
 
     def _optimize_futures(self, expr):
         """

--- a/prefect_ray/task_runners.py
+++ b/prefect_ray/task_runners.py
@@ -149,9 +149,9 @@ class RayTaskRunner(BaseTaskRunner):
         remote_options = RemoteOptionsContext.get().current_remote_options
         # Ray does not support the submission of async functions and we must create a
         # sync entrypoint
-        self._ray_refs[key] = ray.remote(
+        self._ray_refs[key] = ray.remote(**remote_options)(
             sync_compatible(call.func)
-        ).options(**remote_options).remote(**call_kwargs)
+        ).remote(**call_kwargs)
 
     def _optimize_futures(self, expr):
         """

--- a/prefect_ray/task_runners.py
+++ b/prefect_ray/task_runners.py
@@ -149,7 +149,11 @@ class RayTaskRunner(BaseTaskRunner):
         remote_options = RemoteOptionsContext.get().current_remote_options
         # Ray does not support the submission of async functions and we must create a
         # sync entrypoint
-        self._ray_refs[key] = ray.remote(**remote_options)(
+        if remote_options:
+            ray_decorator = ray.remote(**remote_options)
+        else:
+            ray_decorator = ray.remote
+        self._ray_refs[key] = ray_decorator(
             sync_compatible(call.func)
         ).remote(**call_kwargs)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-ray 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

This PR fixes the `prefect_ray.remote_options` feature. Without this fix, it is possible to get an error of the form

```
AssertionError: The @ray.remote decorator must be applied either with no arguments and no parentheses, for example '@ray.remote', or it must be applied using some of the arguments in the list ['max_calls', 'max_retries', 'num_cpus', 'num_returns', 'object_store_memory', 'retry_exceptions', 'concurrency_groups', 'lifetime', 'max_concurrency', 'max_restarts', 'max_task_retries', 'max_pending_calls', 'namespace', 'get_if_exists', 'accelerator_type', 'memory', 'name', 'num_gpus', 'placement_group', 'placement_group_bundle_index', 'placement_group_capture_child_tasks', 'resources', 'runtime_env', 'scheduling_strategy', '_metadata'], for example '@ray.remote(num_returns=2, resources={"CustomResource": 1})'.
```

<!-- Link to issue -->
Closes #

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-ray/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-ray/blob/main/CHANGELOG.md)
