### PR TITLE
Fix `RayTaskRunner` exception handling in Prefect >= 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated `RayTaskRunner` to handle task exceptions correctly in Prefect >= 2.6.0 - [#60](https://github.com/PrefectHQ/prefect-ray/pull/60)
+
 ### Security
 
 ## 0.2.1

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -207,7 +207,7 @@ class TestRayTaskRunner(TaskRunnerStandardTestSuite):
                 key=test_key,
             )
 
-            state = await (await task_runner.wait(test_key, 5))
+            state = await task_runner.wait(test_key, 5)
             assert state is not None, "wait timed out"
             assert isinstance(state, State), "wait should return a state"
             assert state.name == "Crashed"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-ray 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
In Prefect 2.6.0, `exception_to_crashed_state` changed from a sync function to an async function that needs to be awaited. `RayTaskRunner` does not currently await this call, resulting in users seeing `coroutine' object has no attribute 'type'` when an unhandled exception occurs while a Ray worker node is trying to unpickle and load the task. 

Consequently, it is difficult to see and understand what went wrong. Looking at logs from the Ray worker node(s) that tried to execute the failed task(s) will usually show what went wrong, but not all users who can submit work to a Ray cluster will have access to individual worker node logs. 

Several users have encountered this issue, as noted in [this Discourse post](https://discourse.prefect.io/t/edgecase-error-prefect-task-run-task-run-id-already-finished/1836/8?u=ahuang11) and issue #58.

Changes in this PR:
* The task runner now unwraps the original exception whenever possible instead of showing a generic `RayTaskError`
* The task runner now awaits `exception_to_crashed_state` so users will see the actual exception instead of `coroutine' object has no attribute 'result'`
* Added a new test to help prevent future regression to previous behavior. 

<!-- Link to issue -->
Closes #58

### Example
Start by reproducing the error:
* Create a fresh Conda environment or venv
* run `pip install prefect "ray[default]"`
* Create a local Ray cluster by running `ray start --head`
* Run the following flow:
```
from prefect import task, flow
from prefect_ray import RayTaskRunner

task_runner = RayTaskRunner(
    address="ray://localhost:10001"
)

@task()
def test_task():
    raise KeyboardInterrupt()

@flow(task_runner=task_runner)
def test_flow():
    future = test_task.submit()
    future.result(10)

if __name__ == "__main__":
    test_flow()
```
* Notice the `AttributeError: 'coroutine' object has no attribute 'result'` error instead of the error you raised
* Pull in the changes from this PR
* Notice that you now see the actual error caused by the exception: `ray.exceptions.TaskCancelledError: Task: TaskID(...) was cancelled`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-ray/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-ray/blob/main/CHANGELOG.md)
