### PR TITLE
Resolve Ray Futures Decentralized & Concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.3
+
+Released on Februrary 15th, 2023
+
+### Changed
+
+- Resolve Ray Futures Decentralized & Concurrently - [#69](https://github.com/PrefectHQ/prefect-ray/pull/69)
+
 ## 0.2.2
 
 Released on December 1st, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Released on Februrary 15th, 2023
 
 ### Fixed
 
-- Resolve Ray Futures Decentralized & Concurrently - [#69](https://github.com/PrefectHQ/prefect-ray/pull/69)
+- Reduce pressure on networking by resolving Ray/Prefect futures concurrently and decentralized right before executing the Prefect Task. - [#69](https://github.com/PrefectHQ/prefect-ray/pull/69)
 
 ## 0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Released on Februrary 15th, 2023
 
-### Changed
+### Fixed
 
 - Resolve Ray Futures Decentralized & Concurrently - [#69](https://github.com/PrefectHQ/prefect-ray/pull/69)
 

--- a/prefect_ray/task_runners.py
+++ b/prefect_ray/task_runners.py
@@ -159,11 +159,10 @@ class RayTaskRunner(BaseTaskRunner):
         )
 
     def _exchange_prefect_for_ray_futures(self, kwargs_prefect_futures):
-        """
-        Exchanges Prefect futures for Ray futures.
-        """
+        """Exchanges Prefect futures for Ray futures."""
 
         def exchange_prefect_for_ray_future(expr):
+            """Exchanges Prefect future for Ray future."""
             if isinstance(expr, PrefectFuture):
                 ray_future = self._ray_refs.get(expr.key)
                 if ray_future is not None:
@@ -180,11 +179,10 @@ class RayTaskRunner(BaseTaskRunner):
 
     @staticmethod
     def _run_prefect_task(func, *args, **kwargs):
-        """
-        Resolves Ray futures before calling the actual Prefect task function.
-        """
+        """Resolves Ray futures before calling the actual Prefect task function."""
 
         def resolve_ray_future(expr):
+            """Resolves Ray future."""
             if isinstance(expr, ray.ObjectRef):
                 return ray.get(expr)
             return expr

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -292,3 +292,22 @@ class TestRayTaskRunner(TaskRunnerStandardTestSuite):
                 process.submit(42)
 
         my_flow()
+
+    def test_dependencies(self):
+        @task
+        def a():
+            time.sleep(self.get_sleep_time())
+
+        b = c = d = e = a
+
+        @flow(task_runner=RayTaskRunner())
+        def flow_with_dependent_tasks():
+            for _ in range(3):
+                a_future = a.submit(wait_for=[])
+                b_future = b.submit(wait_for=[a_future])
+
+                c.submit(wait_for=[b_future])
+                d.submit(wait_for=[b_future])
+                e.submit(wait_for=[b_future])
+
+        flow_with_dependent_tasks()


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

Closes https://github.com/PrefectHQ/prefect-ray/issues/37

<!-- Overview -->
**Problem Statement**
We recently ran into a performance bottleneck with the current approach of resolving the Ray futures. We ran into these issues with a flow that uses task dependencies. Please take a look at the flow structure below.

Consulting the logs shows that the limiting factor was the networking: We saw a lot of httpx and OpenSSL errors (timeout during handshake, IOerror, ...).

**Hypothesis**
Resolving the Ray futures in a centralized manner puts a lot of pressure on the networking stack and Prefect API. Implementing the changes proposed in https://github.com/PrefectHQ/prefect-ray/issues/37 will eliminate this bottleneck.

**First Tests**
I conducted test runs with my minimum reproducible example (flow executed on my local machine, Ray Cluster provided by Anyscale) and real-world flow + workload (flow executed on AWS EKS flow pod runner, Ray Cluster provided by Anyscale).
They show that we do not run into networking errors anymore with the changes proposed in this PR.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
Flow Structure
```python
for _ in range(do_it_for_a_lot_of_input):
    a_future = a.submit(wait_for=[])
    b_future = b.submit(wait_for=[a_future])

    c_future = c.submit(wait_for=[b_future])
    d_future = d.submit(wait_for=[b_future])
    e_future = e.submit(wait_for=[b_future])
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-ray/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-ray/blob/main/CHANGELOG.md)
