### PR TITLE
'Update the pin on `prefect` version'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           # temporarily remove because Ray doesn't support yet

--- a/prefect_ray/context.py
+++ b/prefect_ray/context.py
@@ -6,7 +6,12 @@ from contextlib import contextmanager
 from typing import Any, Dict
 
 from prefect.context import ContextModel, ContextVar
-from pydantic import Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
 
 
 class RemoteOptionsContext(ContextModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prefect>=2.8.2
+prefect >=2.13.5
 ray[default] >= 1.12.0; python_version >= '3.7' and python_version < '3.10'
 pickle5 >= 0.0.11; python_version < '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-prefect >=2.13.5
+prefect>=2.13.5
 ray[default] >= 1.12.0; python_version >= '3.7' and python_version < '3.10'
 pickle5 >= 0.0.11; python_version < '3.8'

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -316,8 +316,8 @@ class TestRayTaskRunner(TaskRunnerStandardTestSuite):
 
     def test_sync_task_timeout(self, task_runner):
         """
-        This test is inherited from the prefect testing module and it may not appropriately 
-        skip on Windows. Here we skip it explicitly.
+        This test is inherited from the prefect testing module and it may not
+        appropriately skip on Windows. Here we skip it explicitly.
         """
         if sys.platform.startswith("win"):
             pytest.skip("cancellation due to timeouts is not supported on Windows")

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -313,3 +313,12 @@ class TestRayTaskRunner(TaskRunnerStandardTestSuite):
                 e.submit(wait_for=[b_future])
 
         flow_with_dependent_tasks()
+
+    def test_sync_task_timeout(self, task_runner):
+        """
+        This test is inherited from the prefect testing module and it may not appropriately 
+        skip on Windows. Here we skip it explicitly.
+        """
+        if sys.platform.startswith("win"):
+            pytest.skip("cancellation due to timeouts is not supported on Windows")
+        super().test_async_task_timeout(task_runner)


### PR DESCRIPTION
As part of our work adding support for Pydantic 2, we removed its pin in 
`prefect`'s `requirements.txt`. This means that it's possible to have 
`prefect`, `pydantic>=2`, and any version of this collection installed. But, 
the collection(s) only support `pydantic>=2` in their latest versions. This 
PR adds a pin on the collection's `requirements.txt` to make sure that it is 
only installed with the correct version `prefect` that supports `pydantic>=2`