### PR TITLE
use prefect task name as remote function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
-## 0.2.6
 
-Released on 
+## 0.3.3
+
+Released on December 6th, 2023.
 
 ### Added
 
-- Use prefect task name as remote function name.
+- Use perfect task name as Ray remote function name - [#103](https://github.com/PrefectHQ/prefect-ray/pull/103)
 
 ## 0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+## 0.2.6
+
+Released on 
+
+### Added
+
+- Use prefect task name as remote function name.
 
 ## 0.2.5
 

--- a/prefect_ray/task_runners.py
+++ b/prefect_ray/task_runners.py
@@ -173,7 +173,30 @@ class RayTaskRunner(BaseTaskRunner):
         else:
             ray_decorator = ray.remote
 
-        self._ray_refs[key] = ray_decorator(self._run_prefect_task).remote(
+        def _run_prefect_task(func, *upstream_ray_obj_refs, **kwargs):
+            """Resolves Ray futures before calling the actual Prefect task function.
+
+            Passing upstream_ray_obj_refs directly as args enables Ray to wait for
+            upstream tasks before running this remote function.
+            This variable is otherwise unused as the ray object refs are also
+            contained in kwargs.
+            """
+
+            def resolve_ray_future(expr):
+                """Resolves Ray future."""
+                if isinstance(expr, ray.ObjectRef):
+                    return ray.get(expr)
+                return expr
+
+            kwargs = visit_collection(
+                kwargs, visit_fn=resolve_ray_future, return_data=True
+            )
+
+            return func(**kwargs)
+
+        _run_prefect_task.__qualname__ = call.keywords["task_run"].name
+
+        self._ray_refs[key] = ray_decorator(_run_prefect_task).remote(
             sync_compatible(call.func), *upstream_ray_obj_refs, **call_kwargs
         )
 
@@ -198,26 +221,6 @@ class RayTaskRunner(BaseTaskRunner):
         )
 
         return kwargs_ray_futures, upstream_ray_obj_refs
-
-    @staticmethod
-    def _run_prefect_task(func, *upstream_ray_obj_refs, **kwargs):
-        """Resolves Ray futures before calling the actual Prefect task function.
-
-        Passing upstream_ray_obj_refs directly as args enables Ray to wait for
-        upstream tasks before running this remote function.
-        This variable is otherwise unused as the ray object refs are also
-        contained in kwargs.
-        """
-
-        def resolve_ray_future(expr):
-            """Resolves Ray future."""
-            if isinstance(expr, ray.ObjectRef):
-                return ray.get(expr)
-            return expr
-
-        kwargs = visit_collection(kwargs, visit_fn=resolve_ray_future, return_data=True)
-
-        return func(**kwargs)
 
     async def wait(self, key: UUID, timeout: float = None) -> Optional[State]:
         ref = self._get_ray_ref(key)


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #86

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```
from prefect import flow, task
from prefect_ray import RayTaskRunner
from time import sleep

@task(
    name="Worker Task Name",
)
def worker_function():
    sleep(100)


@flow(task_runner=RayTaskRunner)
def main(
):
    worker_function.submit()

if __name__ == "__main__":
    main()
```

![image](https://github.com/PrefectHQ/prefect-ray/assets/11021147/a1775c50-725b-4bea-82f9-e252e046abcc)


### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-ray/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [X] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-ray/blob/main/CHANGELOG.md)
