### PR TITLE
Cap `pytest-asyncio` version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ mkdocs-material
 mkdocstrings[python]
 isort
 pre-commit
-pytest-asyncio
+pytest-asyncio < 0.23.0 # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
 mkdocs-gen-files
 interrogate
 coverage


### PR DESCRIPTION
Cannot override event loop in `pytest-asyncio>0.23.0`. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.